### PR TITLE
extended to work with alt shells

### DIFF
--- a/ytdl.reg
+++ b/ytdl.reg
@@ -1,5 +1,58 @@
 Windows Registry Editor Version 5.00
 
+[HKEY_CLASSES_ROOT\Directory\Background\shell\YoutubeDL]
+"MUIVerb"="youtube-dl"
+"SubCommands"=""
+
+[HKEY_CLASSES_ROOT\Directory\Background\shell\YoutubeDL\shell]
+
+
+
+[HKEY_CLASSES_ROOT\Directory\Background\shell\YoutubeDL\shell\video_mp4]
+@="Download video (H.264)"
+"Icon"="imageres.dll,18"
+
+[HKEY_CLASSES_ROOT\Directory\Background\shell\YoutubeDL\shell\video_mp4\command]
+@="powershell.exe -Command youtube-dl $(Get-Clipboard) '--continue' '--format=bestvideo+bestaudio[ext=m4a]/best' '--merge-output-format=mp4' '--no-check-certificate'"
+
+
+
+[HKEY_CLASSES_ROOT\Directory\Background\shell\YoutubeDL\shell\video]
+@="Download video (DNxHR 25 FPS)"
+"Icon"="imageres.dll,18"
+
+[HKEY_CLASSES_ROOT\Directory\Background\shell\YoutubeDL\shell\video\command]
+@="powershell.exe -NoExit -Command youtube-dl $(Get-Clipboard) '--continue' '--format=bestvideo+bestaudio' '--no-check-certificate' '--exec=ffmpeg -i {} -c:v dnxhd -profile:v dnxhr_hq -vf fps=25/1,format=yuv422p -c:a pcm_s16le {}.mov & del {}'"
+
+
+[HKEY_CLASSES_ROOT\Directory\Background\shell\YoutubeDL\shell\audio_wav]
+@="Download audio (WAV)"
+"Icon"="imageres.dll,103"
+
+[HKEY_CLASSES_ROOT\Directory\Background\shell\YoutubeDL\shell\audio_wav\command]
+@="powershell.exe -Command youtube-dl $(Get-Clipboard) '--no-playlist' '--continue' '-f bestaudio' -x --audio-format wav '--no-check-certificate'"
+
+
+
+[HKEY_CLASSES_ROOT\Directory\Background\shell\YoutubeDL\shell\audio]
+@="Download audio (MP3)"
+"Icon"="imageres.dll,103"
+
+[HKEY_CLASSES_ROOT\Directory\Background\shell\YoutubeDL\shell\audio\command]
+@="powershell.exe -Command youtube-dl $(Get-Clipboard) '--no-playlist' '--continue' '-f bestaudio' -x --audio-format mp3 '--no-check-certificate'"
+
+
+
+
+
+[HKEY_CLASSES_ROOT\Directory\Background\shell\YoutubeDL\shell\z_playlist]
+@="Download playlist"
+"Icon"="imageres.dll,97"
+
+[HKEY_CLASSES_ROOT\Directory\Background\shell\YoutubeDL\shell\z_playlist\command]
+@="powershell.exe -Command youtube-dl $(Get-Clipboard) '--yes-playlist' -o '%%(playlist)s/%%(playlist_index)s - %%(title)s.%%(ext)s' '-i' '--continue' '--format=bestvideo+bestaudio[ext=m4a]/best' '--merge-output-format=mp4' '--no-check-certificate'"
+
+
 [HKEY_CLASSES_ROOT\Folder\shell\YoutubeDL]
 "MUIVerb"="youtube-dl"
 "SubCommands"=""
@@ -42,9 +95,6 @@ Windows Registry Editor Version 5.00
 
 [HKEY_CLASSES_ROOT\Folder\shell\YoutubeDL\shell\audio\command]
 @="powershell.exe -Command Set-Location -LiteralPath ‘%L'; youtube-dl $(Get-Clipboard) '--no-playlist' '--continue' '-f bestaudio' -x --audio-format mp3 '--no-check-certificate'"
-
-
-
 
 
 [HKEY_CLASSES_ROOT\Folder\shell\YoutubeDL\shell\z_playlist]

--- a/ytdl.reg
+++ b/ytdl.reg
@@ -1,56 +1,56 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CLASSES_ROOT\Directory\Background\shell\YoutubeDL]
+[HKEY_CLASSES_ROOT\Folder\shell\YoutubeDL]
 "MUIVerb"="youtube-dl"
 "SubCommands"=""
 
-[HKEY_CLASSES_ROOT\Directory\Background\shell\YoutubeDL\shell]
+[HKEY_CLASSES_ROOT\Folder\shell\YoutubeDL\shell]
 
 
 
-[HKEY_CLASSES_ROOT\Directory\Background\shell\YoutubeDL\shell\video_mp4]
+[HKEY_CLASSES_ROOT\Folder\shell\YoutubeDL\shell\video_mp4]
 @="Download video (H.264)"
 "Icon"="imageres.dll,18"
 
-[HKEY_CLASSES_ROOT\Directory\Background\shell\YoutubeDL\shell\video_mp4\command]
-@="powershell.exe -Command youtube-dl $(Get-Clipboard) '--continue' '--format=bestvideo+bestaudio[ext=m4a]/best' '--merge-output-format=mp4' '--no-check-certificate'"
+[HKEY_CLASSES_ROOT\Folder\shell\YoutubeDL\shell\video_mp4\command]
+@="powershell.exe -Command Set-Location -LiteralPath ‘%L';  youtube-dl $(Get-Clipboard) '--continue' '--format=bestvideo+bestaudio[ext=m4a]/best' '--merge-output-format=mp4' '--no-check-certificate'"
 
 
 
-[HKEY_CLASSES_ROOT\Directory\Background\shell\YoutubeDL\shell\video]
+[HKEY_CLASSES_ROOT\Folder\shell\YoutubeDL\shell\video]
 @="Download video (DNxHR 25 FPS)"
 "Icon"="imageres.dll,18"
 
-[HKEY_CLASSES_ROOT\Directory\Background\shell\YoutubeDL\shell\video\command]
-@="powershell.exe -NoExit -Command youtube-dl $(Get-Clipboard) '--continue' '--format=bestvideo+bestaudio' '--no-check-certificate' '--exec=ffmpeg -i {} -c:v dnxhd -profile:v dnxhr_hq -vf fps=25/1,format=yuv422p -c:a pcm_s16le {}.mov & del {}'"
+[HKEY_CLASSES_ROOT\Folder\shell\YoutubeDL\shell\video\command]
+@="powershell.exe -NoExit -Command Set-Location -LiteralPath ‘%L';  youtube-dl $(Get-Clipboard) '--continue' '--format=bestvideo+bestaudio' '--no-check-certificate' '--exec=ffmpeg -i {} -c:v dnxhd -profile:v dnxhr_hq -vf fps=25/1,format=yuv422p -c:a pcm_s16le {}.mov & del {}'"
 
 
 
 
-[HKEY_CLASSES_ROOT\Directory\Background\shell\YoutubeDL\shell\audio_wav]
+[HKEY_CLASSES_ROOT\Folder\shell\YoutubeDL\shell\audio_wav]
 @="Download audio (WAV)"
 "Icon"="imageres.dll,103"
 
-[HKEY_CLASSES_ROOT\Directory\Background\shell\YoutubeDL\shell\audio_wav\command]
-@="powershell.exe -Command youtube-dl $(Get-Clipboard) '--no-playlist' '--continue' '-f bestaudio' -x --audio-format wav '--no-check-certificate'"
+[HKEY_CLASSES_ROOT\Folder\shell\YoutubeDL\shell\audio_wav\command]
+@="powershell.exe -Command Set-Location -LiteralPath ‘%L';  youtube-dl $(Get-Clipboard) '--no-playlist' '--continue' '-f bestaudio' -x --audio-format wav '--no-check-certificate'"
 
 
 
-[HKEY_CLASSES_ROOT\Directory\Background\shell\YoutubeDL\shell\audio]
+[HKEY_CLASSES_ROOT\Folder\shell\YoutubeDL\shell\audio]
 @="Download audio (MP3)"
 "Icon"="imageres.dll,103"
 
-[HKEY_CLASSES_ROOT\Directory\Background\shell\YoutubeDL\shell\audio\command]
-@="powershell.exe -Command youtube-dl $(Get-Clipboard) '--no-playlist' '--continue' '-f bestaudio' -x --audio-format mp3 '--no-check-certificate'"
+[HKEY_CLASSES_ROOT\Folder\shell\YoutubeDL\shell\audio\command]
+@="powershell.exe -Command Set-Location -LiteralPath ‘%L';  youtube-dl $(Get-Clipboard) '--no-playlist' '--continue' '-f bestaudio' -x --audio-format mp3 '--no-check-certificate'"
 
 
 
 
 
-[HKEY_CLASSES_ROOT\Directory\Background\shell\YoutubeDL\shell\z_playlist]
+[HKEY_CLASSES_ROOT\Folder\shell\YoutubeDL\shell\z_playlist]
 @="Download playlist"
 "Icon"="imageres.dll,97"
 
-[HKEY_CLASSES_ROOT\Directory\Background\shell\YoutubeDL\shell\z_playlist\command]
-@="powershell.exe -Command youtube-dl $(Get-Clipboard) '--yes-playlist' -o '%%(playlist)s/%%(playlist_index)s - %%(title)s.%%(ext)s' '-i' '--continue' '--format=bestvideo+bestaudio[ext=m4a]/best' '--merge-output-format=mp4' '--no-check-certificate'"
+[HKEY_CLASSES_ROOT\Folder\shell\YoutubeDL\shell\z_playlist\command]
+@="powershell.exe -Command Set-Location -LiteralPath ‘%L';  youtube-dl $(Get-Clipboard) '--yes-playlist' -o '%%(playlist)s/%%(playlist_index)s - %%(title)s.%%(ext)s' '-i' '--continue' '--format=bestvideo+bestaudio[ext=m4a]/best' '--merge-output-format=mp4' '--no-check-certificate'"
 @notthebee

--- a/ytdl.reg
+++ b/ytdl.reg
@@ -13,7 +13,7 @@ Windows Registry Editor Version 5.00
 "Icon"="imageres.dll,18"
 
 [HKEY_CLASSES_ROOT\Folder\shell\YoutubeDL\shell\video_mp4\command]
-@="powershell.exe -Command Set-Location -LiteralPath ‘%L';  youtube-dl $(Get-Clipboard) '--continue' '--format=bestvideo+bestaudio[ext=m4a]/best' '--merge-output-format=mp4' '--no-check-certificate'"
+@="powershell.exe -Command Set-Location -LiteralPath ‘%L'; youtube-dl $(Get-Clipboard) '--continue' '--format=bestvideo+bestaudio[ext=m4a]/best' '--merge-output-format=mp4' '--no-check-certificate'"
 
 
 
@@ -22,7 +22,7 @@ Windows Registry Editor Version 5.00
 "Icon"="imageres.dll,18"
 
 [HKEY_CLASSES_ROOT\Folder\shell\YoutubeDL\shell\video\command]
-@="powershell.exe -NoExit -Command Set-Location -LiteralPath ‘%L';  youtube-dl $(Get-Clipboard) '--continue' '--format=bestvideo+bestaudio' '--no-check-certificate' '--exec=ffmpeg -i {} -c:v dnxhd -profile:v dnxhr_hq -vf fps=25/1,format=yuv422p -c:a pcm_s16le {}.mov & del {}'"
+@="powershell.exe -NoExit -Command Set-Location -LiteralPath ‘%L'; youtube-dl $(Get-Clipboard) '--continue' '--format=bestvideo+bestaudio' '--no-check-certificate' '--exec=ffmpeg -i {} -c:v dnxhd -profile:v dnxhr_hq -vf fps=25/1,format=yuv422p -c:a pcm_s16le {}.mov & del {}'"
 
 
 
@@ -32,7 +32,7 @@ Windows Registry Editor Version 5.00
 "Icon"="imageres.dll,103"
 
 [HKEY_CLASSES_ROOT\Folder\shell\YoutubeDL\shell\audio_wav\command]
-@="powershell.exe -Command Set-Location -LiteralPath ‘%L';  youtube-dl $(Get-Clipboard) '--no-playlist' '--continue' '-f bestaudio' -x --audio-format wav '--no-check-certificate'"
+@="powershell.exe -Command Set-Location -LiteralPath ‘%L'; youtube-dl $(Get-Clipboard) '--no-playlist' '--continue' '-f bestaudio' -x --audio-format wav '--no-check-certificate'"
 
 
 
@@ -41,7 +41,7 @@ Windows Registry Editor Version 5.00
 "Icon"="imageres.dll,103"
 
 [HKEY_CLASSES_ROOT\Folder\shell\YoutubeDL\shell\audio\command]
-@="powershell.exe -Command Set-Location -LiteralPath ‘%L';  youtube-dl $(Get-Clipboard) '--no-playlist' '--continue' '-f bestaudio' -x --audio-format mp3 '--no-check-certificate'"
+@="powershell.exe -Command Set-Location -LiteralPath ‘%L'; youtube-dl $(Get-Clipboard) '--no-playlist' '--continue' '-f bestaudio' -x --audio-format mp3 '--no-check-certificate'"
 
 
 
@@ -52,5 +52,5 @@ Windows Registry Editor Version 5.00
 "Icon"="imageres.dll,97"
 
 [HKEY_CLASSES_ROOT\Folder\shell\YoutubeDL\shell\z_playlist\command]
-@="powershell.exe -Command Set-Location -LiteralPath ‘%L';  youtube-dl $(Get-Clipboard) '--yes-playlist' -o '%%(playlist)s/%%(playlist_index)s - %%(title)s.%%(ext)s' '-i' '--continue' '--format=bestvideo+bestaudio[ext=m4a]/best' '--merge-output-format=mp4' '--no-check-certificate'"
+@="powershell.exe -Command Set-Location -LiteralPath ‘%L'; youtube-dl $(Get-Clipboard) '--yes-playlist' -o '%%(playlist)s/%%(playlist_index)s - %%(title)s.%%(ext)s' '-i' '--continue' '--format=bestvideo+bestaudio[ext=m4a]/best' '--merge-output-format=mp4' '--no-check-certificate'"
 @notthebee


### PR DESCRIPTION
By adding the same keys to the `HKEY_CLASSES_ROOT\Folder\shell\` location and extending the commands with `Set-Location -LiteralPath ‘%L';` to move into the directory the command was called from, ytdl-explorer will also work with alternative shells such as Freecommander XE (and presumably also TotalCommander), which call the shell context menu within a folder instead of the directory one.